### PR TITLE
feat(player): default the bottom-left player to plyr.fm radio

### DIFF
--- a/src/app/components/PlyrFmPlayer.tsx
+++ b/src/app/components/PlyrFmPlayer.tsx
@@ -26,7 +26,7 @@ function displayOwner(r: SearchResult): string | undefined {
     return r.owner_display_name ?? r.artist_display_name;
 }
 
-const DEFAULT_EMBED_URL = 'https://plyr.fm/embed/playlist/71f84b8c-4cd4-41ff-a037-7df3d94164aa';
+const DEFAULT_EMBED_URL = 'https://plyr.fm/embed/radio';
 const STORAGE_KEY = 'plyrfm_embed_url';
 
 function embedUrlFor(result: SearchResult): string {


### PR DESCRIPTION
Points the bottom-left music widget's default embed at **`https://plyr.fm/embed/radio`** (the new compact radio embed) instead of the fixed playlist — so it plays the live station by default.

Search-and-select for a specific playlist/track still works and still persists to `localStorage` (so an explicit pick overrides the radio default).

Merging deploys to the live site (deploy.yml on push to main), so I left it as a PR rather than pushing to main directly.

Note: `plyr.fm/embed/radio` is deploying to prod now (plyr.fm#1492); give it a couple minutes before testing the iframe.