### PR TITLE
player: drop localStorage persistence — radio greets every fresh load

### DIFF
--- a/src/app/components/PlyrFmPlayer.tsx
+++ b/src/app/components/PlyrFmPlayer.tsx
@@ -27,7 +27,6 @@ function displayOwner(r: SearchResult): string | undefined {
 }
 
 const DEFAULT_EMBED_URL = 'https://plyr.fm/embed/radio';
-const STORAGE_KEY = 'plyrfm_embed_url';
 
 function embedUrlFor(result: SearchResult): string {
     if (result.type === 'track') return `https://plyr.fm/embed/track/${result.id}`;
@@ -42,11 +41,6 @@ export default function PlyrFmPlayer() {
     const [showResults, setShowResults] = useState(false);
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const resultsRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        const saved = localStorage.getItem(STORAGE_KEY);
-        if (saved) setEmbedUrl(saved);
-    }, []);
 
     const search = useCallback(async (q: string) => {
         if (!q.trim()) {
@@ -78,7 +72,6 @@ export default function PlyrFmPlayer() {
     const selectResult = (result: SearchResult) => {
         const url = embedUrlFor(result);
         setEmbedUrl(url);
-        localStorage.setItem(STORAGE_KEY, url);
         setQuery('');
         setResults([]);
         setShowResults(false);


### PR DESCRIPTION
removes the saved-selection override so the bottom-left player always opens on plyr.fm radio. search-and-select still works, it just only lasts the current page session.

<details>
<summary>why</summary>

a playlist picked via search was saved to localStorage and silently overrode the radio default on every future visit, with no UI to get back to radio (came out of debugging why the radio default from #41 didn't appear). once plyr.fm's embed grows a station flipper (zzstoatzz/plyr.fm#1570), the radio itself becomes the place to choose what plays.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)